### PR TITLE
Fix: Remove duplicate robots.txt configuration

### DIFF
--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://subscriptions-tracker.com/sitemap.xml


### PR DESCRIPTION
This PR fixes a duplicate robots configuration issue.

## Problem
Currently, we have both `robots.ts` and `robots.txt` in the `src/app` directory, which causes Next.js to throw a duplicate page error as both files resolve to `/robots.txt`.

## Solution
- Remove the static `robots.txt` file
- Keep the programmatic `robots.ts` which provides more flexibility and type safety

## Technical Details
- Next.js 13+ prefers the programmatic approach using `robots.ts`
- The `robots.ts` file we have in place already provides all necessary directives
- No functionality is lost by removing the static file

## Testing
- Verified that the error about duplicate pages is resolved
- Confirmed that `/robots.txt` still works correctly through `robots.ts`

## Related Documentation
Next.js documentation about robots configuration:
https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots