### PR TITLE
Fix header navigation to work correctly from subpages

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,11 +3,14 @@
 import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Button } from "./ui/button";
 
 export default function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
+  const pathname = usePathname();
+  const isHomePage = pathname === "/";
 
   useEffect(() => {
     const handleScroll = () => {
@@ -38,6 +41,20 @@ export default function Header() {
     }
   };
 
+  // Helper function to determine link behavior based on current page
+  const getNavigationProps = (sectionId: string) => {
+    if (isHomePage) {
+      return {
+        href: `#${sectionId}`,
+        onClick: (e: React.MouseEvent<HTMLAnchorElement>) => scrollToSection(e, sectionId)
+      };
+    }
+    return {
+      href: `/#${sectionId}`,
+      // No onClick handler for absolute links to homepage sections
+    };
+  };
+
   return (
     <header
       className={cn(
@@ -63,33 +80,40 @@ export default function Header() {
           {/* Navigation */}
           <nav className="hidden md:flex items-center space-x-8">
             <Link
-              href="#features"
+              {...getNavigationProps("features")}
               className="text-sm text-muted-foreground hover:text-primary transition-colors"
-              onClick={(e) => scrollToSection(e, "features")}
             >
               Features
             </Link>
 
             <Link
-              href="#testimonials"
+              {...getNavigationProps("testimonials")}
               className="text-sm text-muted-foreground hover:text-primary transition-colors"
-              onClick={(e) => scrollToSection(e, "testimonials")}
             >
               Testimonials
             </Link>
+            
             <Link
-              href="#faq"
+              {...getNavigationProps("faq")}
               className="text-sm text-muted-foreground hover:text-primary transition-colors"
-              onClick={(e) => scrollToSection(e, "faq")}
             >
               FAQ
             </Link>
+            
+            <Link
+              href="/pricing"
+              className="text-sm text-muted-foreground hover:text-primary transition-colors"
+            >
+              Pricing
+            </Link>
+            
             <Link
               href="https://app.subscriptions-tracker.com/login"
               className="text-sm text-muted-foreground hover:text-primary transition-colors"
             >
               Login
             </Link>
+            
             <Button asChild>
               <Link href="https://app.subscriptions-tracker.com/signup">
                 Get Started


### PR DESCRIPTION
## Header Navigation Fix

This PR addresses the issue where header links only worked correctly on the home page but not on subpages.

### Problem
- On the home page, header links like "Features", "Testimonials", "FAQ" used smooth-scrolling to anchor sections
- On subpages, these links didn't work because the target sections didn't exist on those pages

### Solution
1. Added `usePathname()` hook to detect the current page
2. Created a helper function `getNavigationProps()` that:
   - On the home page: Uses anchor links with smooth scrolling (`#features`)
   - On subpages: Uses absolute links to home page sections (`/#features`)
3. Added a direct "Pricing" link for better navigation

### Implementation details
- Added pathname check: `const isHomePage = pathname === "/";`
- Dynamically generates href and onClick props based on current page
- Preserves smooth scrolling functionality on the home page
- Links now correctly take users back to home page sections when on subpages

This change ensures consistent navigation throughout the site while maintaining the smooth scrolling experience on the home page.