### PR TITLE
Fix: Change default database name from subscriptions_tracker to subscriptions

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,7 +1,7 @@
 import { MongoClient, Db } from 'mongodb';
 
 const uri = process.env.MONGODB_URI || '';
-const dbName = process.env.MONGODB_DB || 'subscriptions_tracker';
+const dbName = process.env.MONGODB_DB || 'subscriptions';
 
 // Cache the MongoDB connection to prevent multiple connections
 let cachedClient: MongoClient | null = null;


### PR DESCRIPTION
## Description
This PR changes the default database name in the database connection from 'subscriptions_tracker' to 'subscriptions' as requested. This ensures that waitlist entries are saved in the correct database.

## Changes Made
- Updated the default value of dbName in src/lib/database.ts
- Changed from 'subscriptions_tracker' to 'subscriptions'

## Testing
- Verify that new waitlist entries are saved to the 'subscriptions' database
- Ensure existing functionality continues to work properly

## Note
- This change only affects the default fallback value when MONGODB_DB environment variable is not set
- If MONGODB_DB is already set in the environment configuration, that value will still be used

## References
- For existing waitlist entries that were saved in the old database, we may need to migrate them (can be addressed separately if needed)