### PR TITLE
Fix: Admin waitlist authentication issues

### DIFF
--- a/src/app/api/admin/waitlist/route.ts
+++ b/src/app/api/admin/waitlist/route.ts
@@ -1,12 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { waitlistService } from '@/lib/services/waitlist-service';
 
+// Default admin key (in production, this should be set via environment variables)
+const DEFAULT_ADMIN_KEY = 'admin-secret-key';
+
 // Helper for authentication - basic implementation for now
 // In a real app, you would use a more robust auth system
 const isAuthenticated = async (req: NextRequest): Promise<boolean> => {
   // Simple API key check (in production, use a proper auth system)
   const apiKey = req.headers.get('x-api-key');
-  const validApiKey = process.env.ADMIN_API_KEY;
+  
+  // Use environment variable if set, otherwise fall back to the default key
+  const validApiKey = process.env.ADMIN_API_KEY || DEFAULT_ADMIN_KEY;
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`Auth check: Received key: ${apiKey}, Valid key: ${validApiKey}`);
+  }
   
   return apiKey === validApiKey;
 };


### PR DESCRIPTION
## Description
This PR fixes the authentication issue that was causing 401 Unauthorized errors when accessing the admin waitlist page. The issue was due to a mismatch between the API keys used in the client and server.

## Changes Made
1. **Server-side API route**:
   - Added a default fallback API key that matches the client-side key
   - Improved error logging for authentication checks
   - Made the authentication method more robust by ensuring keys are consistently used

2. **Client-side Admin Page**:
   - Made the admin API key consistent with the server default
   - Added specific handling for 401 authentication errors
   - Added a user-friendly error display for authentication failures
   - Improved error messaging to help diagnose authentication issues

## Problem Analysis
The 401 error occurred because:
- The server was looking for `process.env.ADMIN_API_KEY` which was likely not set
- The client was using a hardcoded fallback value of 'admin-secret-key'
- This solution ensures both sides use the same key by default, while still allowing override through environment variables

## Testing
- Verify that the waitlist admin page loads without 401 errors
- Check that waitlist entries are displayed correctly
- Verify that the update functions (contacted/converted toggles) work properly
- Test with incorrect API key to ensure the auth error display works as expected

## Security Considerations
- This is a temporary solution for development/testing
- For production, a proper authentication system should be implemented
- Environment variables should be used to set a secure API key rather than using the hardcoded default