### PR TITLE
Fix Admin Authentication for Waitlist Dashboard

### DIFF
--- a/src/app/api/admin/waitlist/route.ts
+++ b/src/app/api/admin/waitlist/route.ts
@@ -5,23 +5,17 @@ import { DEFAULT_ADMIN_KEY, FEATURES } from '@/lib/constants';
 // Helper for authentication - basic implementation for now
 // In a real app, you would use a more robust auth system
 const isAuthenticated = async (req: NextRequest): Promise<boolean> => {
-  // If we're in development mode and auth bypass is enabled, always authenticate
-  if (FEATURES.BYPASS_ADMIN_AUTH) {
-    console.log('Development mode: Bypassing authentication');
-    return true;
-  }
-
   // Simple API key check
   const apiKey = req.headers.get('x-api-key');
   
   // Use environment variable if set, otherwise fall back to the default key
-  const validApiKey = process.env.ADMIN_API_KEY || DEFAULT_ADMIN_KEY;
+  const validApiKey = process.env.NEXT_PUBLIC_ADMIN_API_KEY || DEFAULT_ADMIN_KEY;
   
   // In development, log the authentication details (but not in production)
   if (FEATURES.DEBUG_MODE) {
     console.log('Auth check details:');
     console.log(`- Received key: ${apiKey ? '[present]' : '[missing]'}`);
-    console.log(`- Using env var: ${process.env.ADMIN_API_KEY ? 'Yes' : 'No (using default)'}`);
+    console.log(`- Using env var: ${process.env.NEXT_PUBLIC_ADMIN_API_KEY ? 'Yes' : 'No (using default)'}`);
   }
   
   return apiKey === validApiKey;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,6 +4,7 @@
 
 /**
  * Authentication
+ * This is used as a fallback only if NEXT_PUBLIC_ADMIN_API_KEY env var is not set
  */
 export const DEFAULT_ADMIN_KEY = 'admin-secret-key';
 
@@ -21,8 +22,5 @@ export const FEATURES = {
 
   // Development & testing flags
   MOCK_PAYMENT_FLOW: false, // Enable simulated payment
-  DEBUG_MODE: process.env.NODE_ENV === 'development', // Show debug information in UI
-  
-  // Bypass authentication in development
-  BYPASS_ADMIN_AUTH: process.env.NODE_ENV === 'development'
+  DEBUG_MODE: process.env.NODE_ENV === 'development' // Show debug information in UI
 };


### PR DESCRIPTION
## Problem

The admin waitlist dashboard is not working in production due to a mismatch in the way environment variables are accessed between frontend and backend.

## Solution

This PR fixes the authentication issues by:

1. Using the same environment variable `NEXT_PUBLIC_ADMIN_API_KEY` on both frontend and backend
2. Removing the bypass authentication flag which is not needed
3. Simplifying the authentication logic for consistency between environments

## Implementation Details

- Updated `src/app/api/admin/waitlist/route.ts` to use `NEXT_PUBLIC_ADMIN_API_KEY` instead of `ADMIN_API_KEY`
- Updated `src/lib/constants.ts` to remove the bypass authentication flag and improve documentation
- Ensured consistent environment variable usage across the codebase

## How to Test

1. Make sure to set `NEXT_PUBLIC_ADMIN_API_KEY` in your Vercel environment variables
2. Deploy and verify that the admin waitlist page works properly

## Additional Notes

The frontend component already uses `NEXT_PUBLIC_ADMIN_API_KEY` so no changes were needed there.