### PR TITLE
Fix middleware 404 issue on homepage

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -65,10 +65,12 @@ export async function middleware(request: NextRequest) {
   return NextResponse.next();
 }
 
-// See "Matching Paths" below to learn more
+// Fix: Only protect specific routes that need authentication
 export const config = {
   matcher: [
-    // Match all paths except for static assets, api routes that don't need auth, and next-auth routes
-    '/((?!_next/static|_next/image|favicon.ico).*)',
+    // Only match admin routes and API routes that need protection
+    '/admin/:path*',
+    '/api/admin/:path*',
+    '/auth/:path*'
   ],
 };


### PR DESCRIPTION
## Fix for 404 on Homepage

This PR fixes the 404 error occurring on the main page (http://localhost:3000/) in the local test environment by updating the middleware configuration.

### Changes:

- Modified the middleware matcher to be more specific and only target routes that actually need protection:
  - `/admin/:path*` - The admin panel routes
  - `/api/admin/:path*` - Admin API endpoints
  - `/auth/:path*` - Authentication routes (except /api/auth which is already handled)

### Root Cause:

The previous matcher configuration was too broad, targeting all routes. This caused the middleware to intercept all requests, including the homepage. When there were any issues with the auth setup (like missing environment variables), this would result in 404 errors.

### How to Test:

1. Make sure you have the correct environment variables in your `.env.local`:
   ```
   NEXTAUTH_SECRET=your_secret_here
   NEXTAUTH_URL=http://localhost:3000
   DATABASE_URL=your_database_url
   ```
2. Run the app with `npm run dev`
3. Navigate to http://localhost:3000/
4. The homepage should load correctly
5. Try to access http://localhost:3000/admin - it should redirect to login

This PR ensures that the middleware only runs for routes that need authentication, leaving public routes like the homepage untouched.
